### PR TITLE
Update Samsung.kt

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Samsung.kt
+++ b/app/src/main/java/me/phh/treble/app/Samsung.kt
@@ -14,25 +14,34 @@ import android.telephony.TelephonyManager
 import android.util.Log
 import androidx.annotation.RequiresApi
 import java.io.File
+import android.telephony.SubscriptionManager
 
-object Samsung : EntryStartup {
-    val tspBase = "/sys/devices/virtual/sec/tsp"
-
-    private val spListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
-        when (key) {
+class Samsung: EntryStartup {
+    /*
+    Here lies some documentations about stuff that cane be done on Samsung devices:
+    - For touchscreen, check /sys/devices/virtual/sec/tsp/cmd_list. It can include stuff about pen too
+        - aod_enable/set_aod_rect
+        - brush_enable
+    - For display, check /sys/class/mdnie/mdnie
+        - accesibility: 0 no, 1 negative, 2 color_blind, 3 screen off, 4 grayscale, 5 grayscale_negative, 6 color blind hbm
+        - night mode 1 <0-10> (enable and set level) or 0 0 (disable)
+     */
+    lateinit var context: Context
+    val spListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
+        when(key) {
             SamsungSettings.highBrightess -> {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.sys.samsung.full_brightness", value.toString())
             }
             SamsungSettings.gloveMode -> {
                 val value = sp.getBoolean(key, false)
-                val cmd = if (value) "glove_mode,1" else "glove_mode,0"
+                val cmd = if(value) "glove_mode,1" else "glove_mode,0"
                 val ret = tsCmd(cmd)
                 Log.e("PHH", "Setting glove mode to $cmd got $ret")
             }
             SamsungSettings.audioStereoMode -> {
                 val value = sp.getBoolean(key, false)
-                if (value) {
+                if(value) {
                     AudioSystem.setParameters("Dualspk=1")
                     AudioSystem.setParameters("SpkAmpLPowerOn=1")
                     AudioSystem.setParameters("ProximitySensorClosed=0")
@@ -42,27 +51,27 @@ object Samsung : EntryStartup {
                 }
             }
             SamsungSettings.wirelessChargingTransmit -> {
-                val value = if (sp.getBoolean(key, false)) "1" else "0"
+                val value = if(sp.getBoolean(key, false)) "1" else "0"
                 try {
                     File("/sys/class/power_supply/battery/wc_tx_en").writeText(value + "\n")
-                } catch (e: Exception) {
+                } catch(e: Exception) {
                     Log.e("PHH", "Failed setting wireless charging transmit", e)
                 }
             }
             SamsungSettings.doubleTapToWake -> {
-                val cmd = if (sp.getBoolean(key, false)) "aot_enable,1" else "aot_enable,0"
+                var cmd = if(sp.getBoolean(key, false)) "aot_enable,1" else "aot_enable,0"
                 tsCmd(cmd)
             }
             SamsungSettings.extraSensors -> {
-                val value = if (sp.getBoolean(key, false)) "true" else "false"
+                val value = if(sp.getBoolean(key, false)) "true" else " false"
                 SystemProperties.set("persist.sys.phh.samsung_sensors", value)
             }
             SamsungSettings.colorspace -> {
-                val value = if (sp.getBoolean(key, false)) "true" else "false"
+                val value = if(sp.getBoolean(key, false)) "true" else " false"
                 SystemProperties.set("persist.sys.phh.samsung_colorspace", value)
             }
             SamsungSettings.brokenFingerprint -> {
-                val value = if (sp.getBoolean(key, false)) "1" else "0"
+                val value = if(sp.getBoolean(key, false)) "1" else " 0"
                 SystemProperties.set("persist.sys.phh.samsung_fingerprint", value)
             }
             SamsungSettings.backlightMultiplier -> {
@@ -73,8 +82,13 @@ object Samsung : EntryStartup {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.sys.phh.samsung.camera_ids", value.toString())
             }
+            SamsungSettings.alternateAudioPolicy -> {
+                val b = sp.getBoolean(key, false)
+                val value = if(b) "1" else "0"
+                Misc.safeSetprop("persist.sys.phh.caf.audio_policy", value)
+            }
             SamsungSettings.fodSingleClick -> {
-                val cmd = if (sp.getBoolean(key, false)) "fod_lp_mode,1" else "fod_lp_mode,0"
+                val cmd = if(sp.getBoolean(key, false)) "fod_lp_mode,1" else "fod_lp_mode,0"
                 tsCmd(cmd)
             }
             SamsungSettings.flashStrength -> {
@@ -82,71 +96,111 @@ object Samsung : EntryStartup {
                 SystemProperties.set("persist.sys.phh.flash_strength", value)
             }
             SamsungSettings.disableBackMic -> {
-                val value = if (sp.getBoolean(key, false)) "true" else "false"
+                val value = if(sp.getBoolean(key, false)) "true" else " false"
                 SystemProperties.set("persist.sys.phh.disable_back_mic", value)
             }
         }
     }
 
-    private val telephonyCallback: TelephonyCallback = @RequiresApi(Build.VERSION_CODES.S)
-    object : TelephonyCallback(), TelephonyCallback.CallStateListener {
-        override fun onCallStateChanged(p0: Int) {
-            Log.d("PHH", "Call state changed $p0")
-            if (p0 == TelephonyManager.CALL_STATE_OFFHOOK) {
-                AudioSystem.setParameters("g_call_state=514") // CALL_STATUS_VOLTE_CP_VOICE_CALL_ON
-            } else {
-                AudioSystem.setParameters("g_call_state=1") // CALL_STATUS_CS_VOICE_CP_VIDEO_CALL_OFF
+@RequiresApi(Build.VERSION_CODES.S)
+val telephonyCallback: TelephonyCallback = object : TelephonyCallback(),
+    TelephonyCallback.CallStateListener,
+    TelephonyCallback.ActiveDataSubscriptionIdListener {
+
+    private var activeSimSlot: Int = 1 // Default SIM slot
+
+    override fun onActiveDataSubscriptionIdChanged(subId: Int) {
+ 
+        val sm = context.getSystemService(SubscriptionManager::class.java)
+        val subscriptionInfoList = sm.activeSubscriptionInfoList
+        for (info in subscriptionInfoList) {
+            if (info.subscriptionId == subId) {
+                activeSimSlot = info.simSlotIndex + 1 // simSlotIndex starts from 0
+                Log.d("PHH", "Detected active SIM slot: $activeSimSlot")
+                break
             }
         }
     }
 
+    override fun onCallStateChanged(state: Int) {
+        Log.d("PHH", "Call state changed $state")
+        try {
+            when (state) {
+                TelephonyManager.CALL_STATE_OFFHOOK -> {
+                    val simSlotHex = "0x%02x".format(activeSimSlot)
+                    AudioSystem.setParameters("g_call_sim_slot=$simSlotHex")
+                    AudioSystem.setParameters("g_call_state=514")
+                }
+                else -> {
+                    AudioSystem.setParameters("g_call_state=1")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("PHH", "Error handling call state", e)
+        }
+    }
+}
+
     @RequiresApi(Build.VERSION_CODES.S)
     override fun startup(ctxt: Context) {
-        if (!SamsungSettings.enabled(ctxt)) return
-        Log.d("PHH", "Starting Samsung service")
+        context = ctxt
+        if (!SamsungSettings.enabled()) return
 
-        val handler = Handler(HandlerThread("SamsungThread").apply { start() }.looper)
+        val handler = Handler(HandlerThread("SamsungThread").apply { start()}.looper)
 
         val tm = ctxt.getSystemService(TelephonyManager::class.java)
         tm.registerTelephonyCallback({ p0 -> handler.post(p0) }, telephonyCallback)
 
         Log.d("PHH", "Registered telecom listener for Samsung")
+        //Reset wirelesss charging transmit at every boot
         val sp = PreferenceManager.getDefaultSharedPreferences(ctxt)
 
         sp.edit().putBoolean(SamsungSettings.wirelessChargingTransmit, false).apply()
+
         sp.registerOnSharedPreferenceChangeListener(spListener)
 
+        //Refresh parameters on boot
         spListener.onSharedPreferenceChanged(sp, SamsungSettings.highBrightess)
         spListener.onSharedPreferenceChanged(sp, SamsungSettings.gloveMode)
         spListener.onSharedPreferenceChanged(sp, SamsungSettings.audioStereoMode)
         spListener.onSharedPreferenceChanged(sp, SamsungSettings.doubleTapToWake)
-
         Log.e("PHH", "Samsung TS: ${tsCmd("get_chip_vendor")}:${tsCmd("get_chip_name")}")
+
         Log.e("PHH", "Samsung TS: Supports glove_mode ${tsCmdExists("glove_mode")}")
         Log.e("PHH", "Samsung TS: Supports aod_enable ${tsCmdExists("aod_enable")}")
 
         tsCmd("check_connection")
         tsCmd("fod_enable,1,1,0")
 
-        for (malware in listOf("com.dti.globe", "com.singtel.mysingtel", "com.LogiaGroup.LogiaDeck", "com.mygalaxy")) {
+        for(malware in listOf("com.dti.globe", "com.singtel.mysingtel", "com.LogiaGroup.LogiaDeck", "com.mygalaxy")) {
             try {
-                ctxt.packageManager.setApplicationEnabledSetting(malware, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0)
-            } catch (t: Throwable) {
-                // Ignore exceptions
-            }
+                ctxt.packageManager
+                        .setApplicationEnabledSetting(malware, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0)
+            } catch (t: Throwable) { }
         }
+
     }
 
-    private fun tsCmd(cmd: String): String {
-        File("${tspBase}/cmd").writeText(cmd + "\n")
-        val status = File("${tspBase}/cmd_status").readText().trim()
-        val ret = File("${tspBase}/cmd_result").readText().trim()
-        if (status != "OK") Log.e("PHH", "Samsung TSP answered $status when doing $cmd (Got $ret)")
-        return ret
-    }
+    companion object: EntryStartup {
+        val tspBase = "/sys/devices/virtual/sec/tsp"
+        fun tsCmd(cmd: String): String {
+            File("${tspBase}/cmd").writeText(cmd+"\n")
+            val status = File("${tspBase}/cmd_status").readText().trim()
+            val ret = File("${tspBase}/cmd_result").readText().trim()
+            if(status != "OK") Log.e("PHH", "Samsung TSP answered $status when doing $cmd (Got $ret)")
+            return ret
+        }
 
-    private fun tsCmdExists(cmd: String): Boolean {
-        val supported = File("${tspBase}/cmd_list").readLines()
-        return supported.contains(cmd)
+        fun tsCmdExists(cmd: String): Boolean {
+            val supported = File("${tspBase}/cmd_list").readLines()
+            return supported.contains(cmd)
+        }
+
+        var self: Samsung? = null
+        override fun startup(ctxt: Context) {
+            if (!SamsungSettings.enabled()) return
+            self = Samsung()
+            self!!.startup(ctxt)
+        }
     }
 }


### PR DESCRIPTION
**Devices:**
- Samsung Galaxy M11 (SDM450)
- Samsung Galaxy A11 (SDM450)
- Samsung Galaxy A20s (SDM450)
- --------------------------------------------------------------
###  Expected Behavior (Single SIM Mode)
- Inserting a SIM in slot 1 or slot 2: audio works fine during calls.

---

###  Bug (Dual SIM Mode)
- When both SIMs are inserted:
  - Only one SIM (usually the one with data enabled) has working audio.
  - The second SIM has no audio during calls.
  - Switching call to that SIM results in silence (no mic/no speaker audio).

---

###  Workaround
- Temporarily enable mobile data on the affected SIM **before or during the call**, then disable it again.
- This reinitializes audio routing and makes audio work normally.
- We tested and confirmed this behavior multiple times.

---

###  Notes
- Before patching, **audio only worked on SIM1**.
- After implementing logic to handle `g_call_sim_slot`, `g_call_state` and binding them to the **active data subscription**, audio started working on both SIMs — **but still requires toggling data**.

------
###  Suggestion
Please consider applying this logic in official builds:
- When call starts, auto-switch data briefly to the call SIM to initialize audio path (then revert back after a short delay or after the call ends).
- Or improve internal audio routing behavior based on active call SIM instead of active data SIM.